### PR TITLE
feat: add criteria abstraction for simpler data query

### DIFF
--- a/examples/bun-hono/index.ts
+++ b/examples/bun-hono/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { logger } from 'hono/logger'
-import { configureAppServer } from "@shopware-ag/app-server-sdk-hono";
+import { configureAppServer } from "@shopware-ag/app-server-sdk/integration/hono";
 import { BunSqliteRepository } from "@shopware-ag/app-server-sdk/integration/bun-sqlite";
 import {
   AppServer,
@@ -13,13 +13,15 @@ import {
   BrowserAppModuleRequest,
 } from "@shopware-ag/app-server-sdk/types";
 import { createNotificationResponse } from "@shopware-ag/app-server-sdk/helper/app-actions";
+import { EntityRepository, SyncOperation, SyncService } from "@shopware-ag/app-server-sdk/helper/admin-api";
+import { Criteria } from "@shopware-ag/app-server-sdk/helper/criteria";
 
 const app = new Hono();
 app.use(logger());
 
 configureAppServer(app, {
-  appName: "MyApp",
-  appSecret: "my-secret",
+  appName: "Test",
+  appSecret: "Test",
   shopRepository: new BunSqliteRepository('shop.db'),
 });
 
@@ -41,10 +43,25 @@ app.get("/app/browser", (c) => {
   );
 });
 
-app.post("/app/action-button", (c) => {
+type Product = {
+  id: string;
+  name: string;
+};
+
+app.post("/app/action-button", async (c) => {
   const ctx = c.get("context") as Context<SimpleShop, ActionButtonRequest>;
 
-  return createNotificationResponse("success", "yeeaa");
+  const repository = new EntityRepository<Product>(ctx.httpClient, "product");
+
+  // get the products clicked by action button
+  const entitySearchResult = await repository.search(new Criteria(ctx.payload.data.ids));
+
+  console.log(entitySearchResult.total);
+  console.log(entitySearchResult.first()?.name)
+
+  await repository.upsert(entitySearchResult.data.map(product => ({ id: product.id, name: 'yippiee' })));
+
+  return createNotificationResponse("success", "Product name updated yeaaa");
 });
 
 export default app;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,16 @@
 				"default": "./dist/commonjs/helper/app-actions.js"
 			}
 		},
+		"./helper/criteria": {
+			"import": {
+				"types": "./dist/esm/helper/criteria.d.ts",
+				"default": "./dist/esm/helper/criteria.js"
+			},
+			"require": {
+				"types": "./dist/commonjs/helper/criteria.d.ts",
+				"default": "./dist/commonjs/helper/criteria.js"
+			}
+		},
 		"./integration/hono": {
 			"import": {
 				"types": "./dist/esm/integration/hono.d.ts",
@@ -145,6 +155,7 @@
 			"./package.json": "./package.json",
 			".": "./src/mod.ts",
 			"./helper/app-actions": "./src/helper/app-actions.ts",
+			"./helper/criteria": "./src/helper/criteria.ts",
 			"./integration/hono": "./src/integration/hono.ts",
 			"./integration/cloudflare-kv": "./src/integration/cloudflare-kv.ts",
 			"./integration/deno-kv": "./src/integration/deno-kv.ts",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,26 @@
 				"default": "./dist/commonjs/helper/criteria.js"
 			}
 		},
+		"./helper/admin-api": {
+			"import": {
+				"types": "./dist/esm/helper/admin-api.d.ts",
+				"default": "./dist/esm/helper/admin-api.js"
+			},
+			"require": {
+				"types": "./dist/commonjs/helper/admin-api.d.ts",
+				"default": "./dist/commonjs/helper/admin-api.js"
+			}
+		},
+		"./helper/uuid": {
+			"import": {
+				"types": "./dist/esm/helper/uuid.d.ts",
+				"default": "./dist/esm/helper/uuid.js"
+			},
+			"require": {
+				"types": "./dist/commonjs/helper/uuid.d.ts",
+				"default": "./dist/commonjs/helper/uuid.js"
+			}
+		},
 		"./integration/hono": {
 			"import": {
 				"types": "./dist/esm/integration/hono.d.ts",
@@ -156,6 +176,8 @@
 			".": "./src/mod.ts",
 			"./helper/app-actions": "./src/helper/app-actions.ts",
 			"./helper/criteria": "./src/helper/criteria.ts",
+			"./helper/admin-api": "./src/helper/admin-api.ts",
+			"./helper/uuid": "./src/helper/uuid.ts",
 			"./integration/hono": "./src/integration/hono.ts",
 			"./integration/cloudflare-kv": "./src/integration/cloudflare-kv.ts",
 			"./integration/deno-kv": "./src/integration/deno-kv.ts",

--- a/src/helper/admin-api.test.ts
+++ b/src/helper/admin-api.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from "bun:test";
+
+import type { HttpClient } from "../http-client.js";
+import {
+	ApiContext,
+	EntityRepository,
+	SyncOperation,
+	SyncService,
+	uuid,
+} from "./admin-api.js";
+import { Criteria } from "./criteria.js";
+
+describe("Test UUID helper", () => {
+	test("should generate a valid UUID", () => {
+		expect(uuid()).toMatch(
+			/^[0-9a-f]{8}[0-9a-f]{4}4[0-9a-f]{3}[89ab][0-9a-f]{3}[0-9a-f]{12}$/,
+		);
+	});
+});
+
+describe("ApiContext", () => {
+	test("headers are correctly encoded", () => {
+		expect(new ApiContext().toHeaders()).toEqual({
+			"sw-inheritance": "0",
+			"sw-skip-trigger-flow": "0",
+		});
+	});
+});
+
+describe("EntityRepository", () => {
+	test("search", async () => {
+		const client = {
+			post(url: string, data: unknown, headers: Record<string, string>) {
+				expect(url).toBe("/search/product");
+				return Promise.resolve({ body: { total: 1, data: [] } });
+			},
+		} as unknown as HttpClient;
+
+		const repository = new EntityRepository(client, "product");
+
+		const res = await repository.search(new Criteria());
+
+		expect(res.total).toBe(1);
+		expect(res.data).toEqual([]);
+		expect(res.first()).toBeNull();
+	});
+
+	test("searchIds", async () => {
+		const client = {
+			post(url: string, data: unknown, headers: Record<string, string>) {
+				expect(url).toBe("/search-ids/product");
+				return Promise.resolve({ body: { data: [] } });
+			},
+		} as unknown as HttpClient;
+
+		const repository = new EntityRepository(client, "product");
+
+		const res = await repository.searchIds(new Criteria());
+
+		expect(res).toEqual([]);
+	});
+
+	test("aggregate", async () => {
+		const client = {
+			post(url: string, data: unknown, headers: Record<string, string>) {
+				expect(url).toBe("/aggregate/product");
+				return Promise.resolve({ body: { total: 1, data: [] } });
+			},
+		} as unknown as HttpClient;
+
+		const repository = new EntityRepository(client, "product");
+
+		const res = await repository.aggregate(new Criteria());
+
+		expect(res.total).toBe(1);
+		expect(res.data).toEqual([]);
+	});
+
+	test("upsert", async () => {
+		const client = {
+			post(
+				url: string,
+				data: SyncOperation[],
+				headers: Record<string, string>,
+			) {
+				expect(url).toBe("/_action/sync");
+
+				expect(data).toHaveLength(1);
+				expect(data[0]?.action).toBe("upsert");
+				expect(JSON.stringify(data[0]?.payload)).toBe(
+					JSON.stringify([{ name: "test" }]),
+				);
+
+				return Promise.resolve({ body: {} });
+			},
+		} as unknown as HttpClient;
+
+		const repository = new EntityRepository(client, "product");
+
+		await repository.upsert([{ name: "test" }]);
+	});
+
+	test("delete", async () => {
+		const client = {
+			post(
+				url: string,
+				data: SyncOperation[],
+				headers: Record<string, string>,
+			) {
+				expect(url).toBe("/_action/sync");
+
+				expect(data).toHaveLength(1);
+				expect(data[0]?.action).toBe("delete");
+				expect(JSON.stringify(data[0]?.payload)).toBe(
+					JSON.stringify([{ id: "111" }]),
+				);
+
+				return Promise.resolve({ body: {} });
+			},
+		} as unknown as HttpClient;
+
+		const repository = new EntityRepository(client, "product");
+
+		await repository.delete([{ id: "111" }]);
+	});
+
+	test("deleteByFilters", async () => {
+		const client = {
+			post(
+				url: string,
+				data: SyncOperation[],
+				headers: Record<string, string>,
+			) {
+				expect(url).toBe("/_action/sync");
+
+				expect(data).toHaveLength(1);
+				expect(data[0]?.action).toBe("delete");
+				expect(data[0]?.criteria).toEqual([
+					{ field: "name", type: "equals", value: "test" },
+				]);
+
+				return Promise.resolve({ body: {} });
+			},
+		} as unknown as HttpClient;
+
+		const repository = new EntityRepository(client, "product");
+
+		await repository.deleteByFilters([Criteria.equals("name", "test")]);
+	});
+});
+
+describe("SyncService", () => {
+	test("sync", async () => {
+		const httpClient = {
+			post(url: string, data: unknown, headers: Record<string, string>) {
+				expect(url).toBe("/_action/sync");
+				expect(JSON.stringify(data)).toBe(
+					'[{"key":"test","entity":"product","action":"upsert","payload":[],"criteria":null}]',
+				);
+				return Promise.resolve({ body: {} });
+			},
+		} as unknown as HttpClient;
+
+		const service = new SyncService(httpClient);
+
+		await service.sync([new SyncOperation("test", "product", "upsert", [])]);
+	});
+});

--- a/src/helper/admin-api.ts
+++ b/src/helper/admin-api.ts
@@ -1,0 +1,197 @@
+import type { HttpClient } from "../http-client.js";
+import type { Criteria } from "./criteria.js";
+import type { SingleFilter } from "./criteria.js";
+
+export class ApiContext {
+	private languageId: string | null;
+	inheritance: boolean | null;
+	versionId: string | null;
+	skipTriggerFlows: boolean | null;
+	indexingSkip: string | null;
+	indexingBehaviour: string | null;
+
+	constructor(
+		languageId: string | null = null,
+		inheritance: boolean | null = null,
+		versionId: string | null = null,
+		skipTriggerFlows: boolean | null = null,
+		indexingSkip: string | null = null,
+		indexingBehaviour: string | null = null,
+	) {
+		this.languageId = languageId;
+		this.inheritance = inheritance;
+		this.versionId = versionId;
+		this.skipTriggerFlows = skipTriggerFlows;
+		this.indexingSkip = indexingSkip;
+		this.indexingBehaviour = indexingBehaviour;
+	}
+
+	toHeaders(): Record<string, string> {
+		const headers = {
+			"sw-language-id": this.languageId,
+			"sw-inheritance": this.inheritance === true ? "1" : "0",
+			"sw-version-id": this.versionId,
+			"sw-skip-trigger-flow": this.skipTriggerFlows === true ? "1" : "0",
+			"indexing-skip": this.indexingSkip,
+			"indexing-behavior": this.indexingBehaviour,
+		};
+
+		for (const key of Object.keys(headers)) {
+			// @ts-expect-error
+			if (headers[key] === null) {
+				// @ts-expect-error
+				delete headers[key];
+			}
+		}
+
+		// @ts-expect-error
+		return headers;
+	}
+}
+
+export class EntityRepository<Entity extends object = object> {
+	constructor(
+		private client: HttpClient,
+		private entityName: string,
+	) {
+		this.client = client;
+		this.entityName = entityName;
+	}
+
+	async search<Aggregations = object>(
+		criteria: Criteria,
+		context: ApiContext = new ApiContext(),
+	): Promise<EntitySearchResult<Entity, Aggregations>> {
+		const response = await this.client.post<
+			EntitySearchResponse<Entity, Aggregations>
+		>(`/search/${this.entityName}`, criteria.toPayload(), context.toHeaders());
+
+		return new EntitySearchResult<Entity, Aggregations>(
+			response.body.total,
+			response.body.aggregations,
+			response.body.data,
+		);
+	}
+
+	async searchIds(
+		criteria: Criteria,
+		context: ApiContext = new ApiContext(),
+	): Promise<string[]> {
+		const response = await this.client.post<{ data: string[] }>(
+			`/search-ids/${this.entityName}`,
+			criteria.toPayload(),
+			context.toHeaders(),
+		);
+
+		return response.body.data;
+	}
+
+	async aggregate<Aggregations>(
+		criteria: Criteria,
+		context: ApiContext = new ApiContext(),
+	): Promise<EntitySearchResult<object, Aggregations>> {
+		const response = await this.client.post<
+			EntitySearchResponse<object, Aggregations>
+		>(
+			`/aggregate/${this.entityName}`,
+			criteria.toPayload(),
+			context.toHeaders(),
+		);
+
+		return new EntitySearchResult<object, Aggregations>(
+			response.body.total,
+			response.body.aggregations,
+			response.body.data,
+		);
+	}
+
+	async upsert(
+		payload: Entity[],
+		context: ApiContext = new ApiContext(),
+	): Promise<void> {
+		await new SyncService(this.client).sync(
+			[new SyncOperation("upsert", this.entityName, "upsert", payload)],
+			context,
+		);
+	}
+
+	async delete<DeleteType extends object = { id: string }>(
+		payload: DeleteType[],
+		context: ApiContext = new ApiContext(),
+	): Promise<void> {
+		await new SyncService(this.client).sync(
+			[new SyncOperation("delete", this.entityName, "delete", payload)],
+			context,
+		);
+	}
+
+	async deleteByFilters(
+		filters: SingleFilter[],
+		context: ApiContext = new ApiContext(),
+	): Promise<void> {
+		await new SyncService(this.client).sync(
+			[new SyncOperation("delete", this.entityName, "delete", [], filters)],
+			context,
+		);
+	}
+}
+
+export class SyncService {
+	constructor(private client: HttpClient) {}
+
+	async sync(
+		operations: SyncOperation[],
+		context: ApiContext = new ApiContext(),
+	): Promise<void> {
+		await this.client.post<{ notFound: string[]; deleted: string[] }>(
+			"/_action/sync",
+			operations,
+			context.toHeaders(),
+		);
+	}
+}
+
+export class SyncOperation {
+	constructor(
+		public key: string,
+		public entity: string,
+		public action: "upsert" | "delete",
+		public payload: object[],
+		public criteria: SingleFilter[] | null = null,
+	) {}
+}
+
+type EntitySearchResponse<Entity = unknown, Aggregations = object> = {
+	total: number;
+	aggregations: Aggregations;
+	data: Entity[];
+};
+
+export class EntitySearchResult<Entity = unknown, Aggregations = object> {
+	constructor(
+		public total: number,
+		public aggregations: Aggregations,
+		public data: Entity[],
+	) {
+		this.total = total;
+		this.aggregations = aggregations;
+		this.data = data;
+	}
+
+	first(): Entity | null {
+		return this.data[0] || null;
+	}
+}
+
+export const Defaults = {
+	systemLanguageId: "2fbb5fe2e29a4d70aa5854ce7ce3e20b",
+	liveVersion: "0fa91ce3e96a4bc2be4bd9ce752c3425",
+	systemCurrencyId: "b7d2554b0ce847cd82f3ac9bd1c0dfca",
+	salesChannelTypeApi: "f183ee5650cf4bdb8a774337575067a6",
+	salesChannelTypeSalesChannel: "8a243080f92e4c719546314b577cf82b",
+	salesChannelTypeProductComparision: "ed535e5722134ac1aa6524f73e26881b",
+};
+
+export function uuid(): string {
+	return crypto.randomUUID().replaceAll("-", "");
+}

--- a/src/helper/criteria.test.ts
+++ b/src/helper/criteria.test.ts
@@ -1,20 +1,12 @@
 import { describe, expect, test } from "bun:test";
-import Criteria, { setDefaultValues } from "./criteria.js";
+import { Criteria, TotalCountMode } from "./criteria.js";
 
 describe("Test Criteria class", () => {
 	test("should default to page===1 & limit===0", () => {
 		const criteria = new Criteria();
 
 		expect(criteria.getLimit()).toBe(0);
-		expect(criteria.getPage()).toBe(1);
-	});
-
-	test("should respect altered default values", () => {
-		setDefaultValues({ limit: 42 });
-		const criteria = new Criteria();
-
-		expect(criteria.getLimit()).toBe(42);
-		expect(criteria.getPage()).toBe(1);
+		expect(criteria.getPage()).toBe(0);
 	});
 
 	test("should able to add a title", () => {
@@ -134,16 +126,6 @@ describe("Test Criteria class", () => {
 		expect(criteria.toPayload().sort).toBeUndefined();
 	});
 
-	test("add group", () => {
-		const criteria = new Criteria();
-
-		criteria.addGroupField("foo");
-
-		const obj = criteria.toPayload();
-
-		expect(obj.groupFields).toEqual(["foo"]);
-	});
-
 	test("add includes", () => {
 		const criteria = new Criteria();
 
@@ -162,5 +144,252 @@ describe("Test Criteria class", () => {
 		const obj = criteria.toPayload();
 
 		expect(obj.ids).toEqual(["foo"]);
+	});
+
+	test("set count mode", () => {
+		const criteria = new Criteria();
+
+		criteria.setTotalCountMode(TotalCountMode.NO_TOTAL_COUNT);
+
+		const obj = criteria.toPayload();
+
+		expect(obj["total-count-mode"]).toBe(TotalCountMode.NO_TOTAL_COUNT);
+	});
+
+	test("set page, limit", () => {
+		const criteria = new Criteria();
+
+		criteria.setPage(1);
+		criteria.setLimit(10);
+
+		const obj = criteria.toPayload();
+
+		expect(obj.page).toBe(1);
+		expect(obj.limit).toBe(10);
+	});
+
+	test("set term", () => {
+		const criteria = new Criteria();
+
+		criteria.setTerm("foo");
+
+		const obj = criteria.toPayload();
+
+		expect(obj.term).toBe("foo");
+	});
+
+	test("add post filter", () => {
+		const criteria = new Criteria();
+
+		criteria.addPostFilter(Criteria.equals("foo", "bar"));
+
+		const obj = criteria.toPayload();
+
+		expect(obj["post-filter"]).toEqual([
+			{ type: "equals", field: "foo", value: "bar" },
+		]);
+	});
+
+	test("add query", () => {
+		const criteria = new Criteria();
+
+		criteria.addQuery(Criteria.equals("foo", "bar"), 100);
+
+		const obj = criteria.toPayload();
+
+		expect(obj.query).toEqual([
+			{ score: 100, query: { type: "equals", field: "foo", value: "bar" } },
+		]);
+	});
+
+	test("add query with score field", () => {
+		const criteria = new Criteria();
+
+		criteria.addQuery(Criteria.equals("foo", "bar"), 100, "test");
+
+		const obj = criteria.toPayload();
+
+		expect(obj.query).toEqual([
+			{
+				score: 100,
+				query: { type: "equals", field: "foo", value: "bar" },
+				scoreField: "test",
+			},
+		]);
+	});
+
+	test("add grouping field", () => {
+		const criteria = new Criteria();
+
+		criteria.addGrouping("foo");
+
+		const obj = criteria.toPayload();
+
+		expect(obj.grouping).toEqual(["foo"]);
+	});
+
+	test("add fields", () => {
+		const criteria = new Criteria();
+
+		criteria.addFields("foo");
+
+		const obj = criteria.toPayload();
+
+		expect(obj.fields).toEqual(["foo"]);
+	});
+
+	test("add aggregations", () => {
+		const criteria = new Criteria();
+
+		criteria.addAggregation(Criteria.avg("foo", "bar"));
+
+		const obj = criteria.toPayload();
+
+		expect(obj.aggregations).toEqual([
+			{ name: "foo", type: "avg", field: "bar" },
+		]);
+	});
+
+	test("aggregations", () => {
+		expect(Criteria.stats("test", "test")).toEqual({
+			name: "test",
+			type: "stats",
+			field: "test",
+		});
+		expect(Criteria.avg("test", "test")).toEqual({
+			name: "test",
+			type: "avg",
+			field: "test",
+		});
+		expect(Criteria.max("test", "test")).toEqual({
+			name: "test",
+			type: "max",
+			field: "test",
+		});
+		expect(Criteria.min("test", "test")).toEqual({
+			name: "test",
+			type: "min",
+			field: "test",
+		});
+		expect(Criteria.count("test", "test")).toEqual({
+			name: "test",
+			type: "count",
+			field: "test",
+		});
+		expect(Criteria.sum("test", "test")).toEqual({
+			name: "test",
+			type: "sum",
+			field: "test",
+		});
+		expect(Criteria.terms("test", "test")).toEqual({
+			name: "test",
+			type: "terms",
+			field: "test",
+			limit: null,
+			sort: null,
+			aggregation: null,
+		});
+		expect(Criteria.entityAggregation("test", "test", "product")).toEqual({
+			name: "test",
+			type: "entity",
+			field: "test",
+			definition: "product",
+		});
+		expect(
+			Criteria.filter(
+				"test",
+				[Criteria.equals("test", "test")],
+				Criteria.sum("test", "test"),
+			),
+		).toEqual({
+			name: "test",
+			type: "filter",
+			filter: [{ type: "equals", field: "test", value: "test" }],
+			aggregation: { name: "test", type: "sum", field: "test" },
+		});
+		expect(Criteria.histogram("test", "test")).toEqual({
+			name: "test",
+			type: "histogram",
+			field: "test",
+			aggregation: null,
+			format: null,
+			interval: null,
+			timeZone: null,
+		});
+	});
+
+	test("filters", () => {
+		expect(Criteria.contains("test", "test")).toEqual({
+			type: "contains",
+			field: "test",
+			value: "test",
+		});
+		expect(Criteria.equals("test", "test")).toEqual({
+			type: "equals",
+			field: "test",
+			value: "test",
+		});
+		expect(Criteria.equalsAny("test", ["test"])).toEqual({
+			type: "equalsAny",
+			field: "test",
+			value: ["test"],
+		});
+		expect(Criteria.prefix("test", "test")).toEqual({
+			type: "prefix",
+			field: "test",
+			value: "test",
+		});
+		expect(Criteria.range("test", { gt: "test" })).toEqual({
+			type: "range",
+			field: "test",
+			parameters: { gt: "test" },
+		});
+		expect(Criteria.suffix("test", "test")).toEqual({
+			type: "suffix",
+			field: "test",
+			value: "test",
+		});
+		expect(Criteria.not("and", [Criteria.equals("test", "test")])).toEqual({
+			type: "not",
+			operator: "and",
+			queries: [{ type: "equals", field: "test", value: "test" }],
+		});
+		expect(Criteria.multi("and", [Criteria.equals("test", "test")])).toEqual({
+			type: "multi",
+			operator: "and",
+			queries: [{ type: "equals", field: "test", value: "test" }],
+		});
+	});
+
+	test("get criteria gives same instance", () => {
+		const criteria = new Criteria();
+
+		const inner = criteria.getAssociation("foo");
+
+		expect(inner).toBe(criteria.getAssociation("foo"));
+	});
+
+	test("natural sorting", () => {
+		const criteria = new Criteria();
+
+		criteria.addSorting(Criteria.naturalSorting("foo", "ASC"));
+
+		const obj = criteria.toPayload();
+
+		expect(obj.sort).toEqual([
+			{ field: "foo", naturalSorting: true, order: "ASC" },
+		]);
+	});
+
+	test("count sorting", () => {
+		const criteria = new Criteria();
+
+		criteria.addSorting(Criteria.countSorting("foo", "ASC"));
+
+		const obj = criteria.toPayload();
+
+		expect(obj.sort).toEqual([
+			{ field: "foo", naturalSorting: false, order: "ASC", type: "count" },
+		]);
 	});
 });

--- a/src/helper/criteria.test.ts
+++ b/src/helper/criteria.test.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "bun:test";
+import Criteria, { setDefaultValues } from "./criteria.js";
+
+describe("Test Criteria class", () => {
+	test("should default to page===1 & limit===0", () => {
+		const criteria = new Criteria();
+
+		expect(criteria.getLimit()).toBe(0);
+		expect(criteria.getPage()).toBe(1);
+	});
+
+	test("should respect altered default values", () => {
+		setDefaultValues({ limit: 42 });
+		const criteria = new Criteria();
+
+		expect(criteria.getLimit()).toBe(42);
+		expect(criteria.getPage()).toBe(1);
+	});
+
+	test("should able to add a title", () => {
+		const criteria = new Criteria();
+
+		expect(criteria.getTitle()).toBe(null);
+		criteria.setTitle("foo");
+		expect(criteria.getTitle()).toBe("foo");
+	});
+
+	test("add assosication", () => {
+		const criteria = new Criteria();
+
+		criteria.addAssociation("foo");
+
+		const obj = criteria.toPayload();
+
+		expect(obj.associations).toEqual({ foo: {} });
+	});
+
+	test("add nested assosication", () => {
+		const criteria = new Criteria();
+
+		criteria.addAssociation("foo.bar");
+
+		const obj = criteria.toPayload();
+
+		expect(obj.associations).toEqual({ foo: { associations: { bar: {} } } });
+	});
+
+	test("get association", () => {
+		const criteria = new Criteria();
+
+		const inner = criteria.getAssociation("foo");
+
+		expect(criteria.hasAssociation("foo")).toBe(true);
+
+		inner.setLimit(10);
+
+		const obj = criteria.toPayload();
+
+		expect(obj.associations).toEqual({ foo: { limit: 10 } });
+	});
+
+	test("add filter", () => {
+		const criteria = new Criteria();
+
+		criteria.addFilter(Criteria.equals("foo", "bar"));
+
+		const obj = criteria.toPayload();
+
+		expect(obj.filter).toEqual([
+			{ type: "equals", field: "foo", value: "bar" },
+		]);
+
+		expect(Criteria.avg("foo", "field")).toEqual({
+			name: "foo",
+			type: "avg",
+			field: "field",
+		});
+		expect(Criteria.count("foo", "field")).toEqual({
+			name: "foo",
+			type: "count",
+			field: "field",
+		});
+		expect(Criteria.equals("foo", "field")).toEqual({
+			value: "field",
+			type: "equals",
+			field: "foo",
+		});
+		expect(Criteria.range("foo", { lt: "1" })).toEqual({
+			type: "range",
+			field: "foo",
+			parameters: { lt: "1" },
+		});
+		expect(Criteria.range("foo", { gt: "1" })).toEqual({
+			type: "range",
+			field: "foo",
+			parameters: { gt: "1" },
+		});
+		expect(Criteria.range("foo", { lte: "1" })).toEqual({
+			type: "range",
+			field: "foo",
+			parameters: { lte: "1" },
+		});
+		expect(Criteria.range("foo", { gte: "1" })).toEqual({
+			type: "range",
+			field: "foo",
+			parameters: { gte: "1" },
+		});
+
+		expect(Criteria.max("foo", "field")).toEqual({
+			name: "foo",
+			type: "max",
+			field: "field",
+		});
+		expect(Criteria.min("foo", "field")).toEqual({
+			name: "foo",
+			type: "min",
+			field: "field",
+		});
+	});
+
+	test("add sort", () => {
+		const criteria = new Criteria();
+
+		criteria.addSorting(Criteria.sort("foo", "ASC"));
+
+		const obj = criteria.toPayload();
+
+		expect(obj.sort).toEqual([
+			{ field: "foo", naturalSorting: false, order: "ASC" },
+		]);
+
+		criteria.resetSorting();
+
+		expect(criteria.toPayload().sort).toBeUndefined();
+	});
+
+	test("add group", () => {
+		const criteria = new Criteria();
+
+		criteria.addGroupField("foo");
+
+		const obj = criteria.toPayload();
+
+		expect(obj.groupFields).toEqual(["foo"]);
+	});
+
+	test("add includes", () => {
+		const criteria = new Criteria();
+
+		criteria.addIncludes({ foo: ["blaa"] });
+
+		const obj = criteria.toPayload();
+
+		expect(obj.includes).toEqual({ foo: ["blaa"] });
+	});
+
+	test("add ids", () => {
+		const criteria = new Criteria();
+
+		criteria.setIds(["foo"]);
+
+		const obj = criteria.toPayload();
+
+		expect(obj.ids).toEqual(["foo"]);
+	});
+});

--- a/src/helper/criteria.ts
+++ b/src/helper/criteria.ts
@@ -1,0 +1,782 @@
+export enum TotalCountMode {
+	/* No total count will be selected. Should be used if no pagination required (fastest) */
+	NO_TOTAL_COUNT = 0,
+	/* Exact total count will be selected. Should be used if an exact pagination is required (slow) */
+	EXACT_TOTAL_COUNT = 1,
+	/* Fetches limit * 5 + 1. Should be used if pagination can work with "next page exists" (fast) */
+	PAGINATION_TOTAL_COUNT = 2,
+}
+
+interface Filters {
+	contains: {
+		type: "contains";
+		field: string;
+		value: string;
+	};
+	prefix: {
+		type: "prefix";
+		field: string;
+		value: string;
+	};
+	suffix: {
+		type: "suffix";
+		field: string;
+		value: string;
+	};
+	equalsAny: {
+		type: "equalsAny";
+		field: string;
+		value: string;
+	};
+	equals: {
+		type: "equals";
+		field: string;
+		value: string | number | boolean | null;
+	};
+	range: {
+		type: "range";
+		field: string;
+		parameters: {
+			lte?: string | number;
+			lt?: string | number;
+			gte?: string | number;
+			gt?: string | number;
+		};
+	};
+	not: {
+		type: "not";
+		operator: "and" | "AND" | "or" | "OR";
+		queries: SingleFilter[];
+	};
+	multi: {
+		type: "multi";
+		operator: "and" | "AND" | "or" | "OR";
+		queries: SingleFilter[];
+	};
+}
+
+interface Aggregations {
+	histogram: {
+		type: "histogram";
+		name: string;
+		field: string;
+		interval: string | null;
+		format: string | null;
+		aggregation: Aggregation | null;
+		timeZone: string | null;
+	};
+	terms: {
+		type: "terms";
+		name: string;
+		field: string;
+		limit: number | null;
+		sort: Sorting | null;
+		aggregation: Aggregation | null;
+	};
+	sum: {
+		type: "sum";
+		name: string;
+		field: string;
+	};
+	stats: {
+		type: "stats";
+		name: string;
+		field: string;
+	};
+	min: {
+		type: "min";
+		name: string;
+		field: string;
+	};
+	max: {
+		type: "max";
+		name: string;
+		field: string;
+	};
+	count: {
+		type: "count";
+		name: string;
+		field: string;
+	};
+	avg: {
+		type: "avg";
+		name: string;
+		field: string;
+	};
+	entity: {
+		type: "entity";
+		name: string;
+		field: string;
+		definition: string;
+	};
+	filter: {
+		type: "filter";
+		name: string;
+		filter: SingleFilter[];
+		aggregation: Aggregation;
+	};
+}
+
+type ValueOf<T> = T[keyof T];
+type SingleFilter = ValueOf<Filters>;
+type Aggregation = ValueOf<Aggregations>;
+
+interface Include {
+	[entityName: string]: string[];
+}
+interface Association {
+	association: string;
+	criteria: Criteria;
+}
+interface Query {
+	score: number;
+	query: SingleFilter;
+	[scoreField: string]: unknown;
+}
+interface Sorting {
+	field: string;
+	order: "ASC" | "DESC";
+	naturalSorting: boolean;
+	type?: string;
+}
+type GroupField = string;
+interface RequestParams {
+	ids?: string[];
+	page?: number;
+	limit?: number;
+	term?: string;
+	query?: Query[];
+	filter?: SingleFilter[];
+	"post-filter"?: SingleFilter[];
+	sort?: Sorting[];
+	aggregations?: Aggregation[];
+	groupFields?: GroupField[];
+	grouping?: string[];
+	fields?: string[];
+	associations?: {
+		[association: string]: RequestParams;
+	};
+	includes?: Include;
+	"total-count-mode"?: TotalCountMode;
+}
+
+export default class Criteria {
+	title: string | null;
+
+	page: number | null;
+
+	limit: number | null;
+
+	term: string | null;
+
+	filters: SingleFilter[];
+
+	ids: string[];
+
+	queries: Query[];
+
+	associations: Association[];
+
+	postFilter: SingleFilter[];
+
+	sortings: Sorting[];
+
+	aggregations: Aggregation[];
+
+	grouping: string[];
+
+	fields: string[];
+
+	groupFields: GroupField[];
+
+	totalCountMode: TotalCountMode | null;
+
+	includes: Include | null;
+
+	constructor(page: number | null = null, limit: number | null = null) {
+		this.page = page;
+		this.limit = limit;
+		this.term = null;
+		this.title = null;
+		this.filters = [];
+		this.includes = null;
+		this.ids = [];
+		this.queries = [];
+		this.associations = [];
+		this.postFilter = [];
+		this.sortings = [];
+		this.aggregations = [];
+		this.grouping = [];
+		this.groupFields = [];
+		this.fields = [];
+		this.totalCountMode = null;
+	}
+
+	/**
+	 * Parses the current criteria and generates an object which can be provided to the api
+	 */
+	toPayload(): RequestParams {
+		const params: RequestParams = {};
+
+		if (this.ids.length > 0) {
+			params.ids = this.ids;
+		}
+		if (this.page !== null) {
+			params.page = this.page;
+		}
+		if (this.limit !== null) {
+			params.limit = this.limit;
+		}
+		if (this.term !== null) {
+			params.term = this.term;
+		}
+		if (this.queries.length > 0) {
+			params.query = this.queries;
+		}
+		if (this.filters.length > 0) {
+			params.filter = this.filters;
+		}
+		if (this.postFilter.length > 0) {
+			params["post-filter"] = this.postFilter;
+		}
+		if (this.sortings.length > 0) {
+			params.sort = this.sortings;
+		}
+		if (this.aggregations.length > 0) {
+			params.aggregations = this.aggregations;
+		}
+		if (this.groupFields.length > 0) {
+			params.groupFields = this.groupFields;
+		}
+		if (this.grouping.length > 0) {
+			params.grouping = this.grouping;
+		}
+		if (this.fields.length > 0) {
+			params.fields = this.fields;
+		}
+		if (this.associations.length > 0) {
+			params.associations = {};
+
+			for (const item of this.associations) {
+				if (!params.associations) {
+					continue;
+				}
+				params.associations[item.association] = item.criteria.toPayload();
+			}
+		}
+		if (this.includes !== null) {
+			params.includes = this.includes;
+		}
+
+		if (this.totalCountMode !== null) {
+			params["total-count-mode"] = this.totalCountMode;
+		}
+
+		return params;
+	}
+
+	/**
+	 * Allows to provide a title for the criteria. This title will be shown in the `repository.search` request url so it can be used for debugging in network's tab
+	 */
+	setTitle(title: string): this {
+		this.title = title;
+		return this;
+	}
+
+	getTitle(): string | null {
+		return this.title;
+	}
+	/**
+	 * Allows to provide a list of ids which are used as a filter
+	 */
+	setIds(ids: string[]): this {
+		this.ids = ids;
+		return this;
+	}
+
+	/**
+	 * Allows to configure the total value of a search result.
+	 * 0 - no total count will be selected. Should be used if no pagination required (fastest)
+	 * 1 - exact total count will be selected. Should be used if an exact pagination is required (slow)
+	 * 2 - fetches limit * 5 + 1. Should be used if pagination can work with "next page exists" (fast)
+	 */
+	setTotalCountMode(mode: TotalCountMode): this {
+		if (typeof mode !== "number") {
+			this.totalCountMode = null;
+		}
+
+		this.totalCountMode = mode < 0 || mode > 2 ? null : mode;
+		return this;
+	}
+
+	setPage(page: number): this {
+		this.page = page;
+		return this;
+	}
+
+	setLimit(limit: number): this {
+		this.limit = limit;
+		return this;
+	}
+
+	setTerm(term: string): this {
+		this.term = term;
+		return this;
+	}
+
+	addFilter(filter: SingleFilter): this {
+		this.filters.push(filter);
+
+		return this;
+	}
+
+	addIncludes(include: Include): this {
+		for (const [entityName, includeValues] of Object.entries(include)) {
+			if (this.includes === null) {
+				this.includes = {};
+			}
+			if (!this.includes[entityName]) {
+				this.includes[entityName] = [];
+			}
+
+			this.includes[entityName].push(...includeValues);
+		}
+
+		return this;
+	}
+
+	/**
+	 * Adds the provided filter as post filter.
+	 * Post filter will be considered for the documents query but not for the aggregations.
+	 */
+	addPostFilter(filter: SingleFilter): this {
+		this.postFilter.push(filter);
+		return this;
+	}
+
+	/**
+	 * Allows to add different sortings for the criteria, to sort the entity result.
+	 */
+	addSorting(sorting: Sorting): this {
+		this.sortings.push(sorting);
+		return this;
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Query\ScoreQuery.
+	 * These queries are used to search for documents and score them with a ranking
+	 */
+	addQuery(
+		filter: SingleFilter,
+		score: number,
+		scoreField: string | null = null,
+	): this {
+		const query: Query = { score: score, query: filter };
+
+		if (scoreField) {
+			query[scoreField] = scoreField;
+		}
+
+		this.queries.push(query);
+
+		return this;
+	}
+
+	/**
+	 * @param {Object} groupField
+	 */
+	addGroupField(groupField: GroupField): this {
+		this.groupFields.push(groupField);
+		return this;
+	}
+
+	/**
+	 * Allows grouping the result by a specific field
+	 */
+	addGrouping(field: string): this {
+		this.grouping.push(field);
+
+		return this;
+	}
+
+	/**
+	 * Allows loading partial fields for the result.
+	 */
+	addFields(...field: string[]): this {
+		this.fields.push(...field);
+
+		return this;
+	}
+
+	/**
+	 * @param {Object} aggregation
+	 */
+	addAggregation(aggregation: Aggregation): this {
+		this.aggregations.push(aggregation);
+		return this;
+	}
+
+	/**
+	 * Ensures that a criterion is created for each segment of the passed path.
+	 * Existing Criteria objects are not overwritten.
+	 * Returns the own instance
+	 */
+	addAssociation(path: string): this {
+		this.getAssociation(path);
+
+		return this;
+	}
+
+	/**
+	 * Ensures that a criterion is created for each segment of the passed path.
+	 * Returns the criteria instance of the last path segment
+	 */
+	getAssociation(path: string): Criteria {
+		const parts = path.split(".");
+
+		// eslint-disable-next-line @typescript-eslint/no-this-alias
+		let criteria = this;
+
+		for (const part of parts) {
+			if (!criteria.hasAssociation(part)) {
+				criteria.associations.push({
+					association: part,
+					criteria: new Criteria(null, null),
+				});
+			}
+
+			// @ts-expect-error - another this instance
+			criteria = criteria.getAssociationCriteria(part);
+		}
+
+		return criteria;
+	}
+
+	private getAssociationCriteria(part: string): Criteria {
+		let criteria = null;
+
+		for (const association of this.associations) {
+			if (association.association === part) {
+				criteria = association.criteria;
+			}
+		}
+
+		if (!criteria) {
+			criteria = new Criteria(null, null);
+			this.associations.push({
+				association: part,
+				criteria,
+			});
+		}
+
+		return criteria;
+	}
+
+	getLimit(): number {
+		return this.limit ?? 0;
+	}
+
+	getPage(): number {
+		return this.page ?? 0;
+	}
+
+	getCriteriaData(): {
+		page: Criteria["page"];
+		limit: Criteria["limit"];
+		term: Criteria["term"];
+		title: Criteria["title"];
+		filters: Criteria["filters"];
+		ids: Criteria["ids"];
+		queries: Criteria["queries"];
+		associations: Criteria["associations"];
+		postFilter: Criteria["postFilter"];
+		sortings: Criteria["sortings"];
+		aggregations: Criteria["aggregations"];
+		grouping: Criteria["grouping"];
+		fields: Criteria["fields"];
+		groupFields: Criteria["groupFields"];
+		totalCountMode: Criteria["totalCountMode"];
+		includes: Criteria["includes"];
+	} {
+		return {
+			page: this.page,
+			limit: this.limit,
+			term: this.term,
+			title: this.title,
+			filters: this.filters,
+			ids: this.ids,
+			queries: this.queries,
+			associations: this.associations,
+			postFilter: this.postFilter,
+			sortings: this.sortings,
+			aggregations: this.aggregations,
+			grouping: this.grouping,
+			fields: this.fields,
+			groupFields: this.groupFields,
+			totalCountMode: this.totalCountMode,
+			includes: this.includes,
+		};
+	}
+
+	hasAssociation(property: string): boolean {
+		return this.associations.some((assocation) => {
+			return assocation.association === property;
+		});
+	}
+
+	/**
+	 * Resets the sorting parameter
+	 */
+	resetSorting(): void {
+		this.sortings = [];
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\AvgAggregation
+	 * Allows to calculate the avg value for the provided field
+	 */
+	static avg(name: string, field: string): Aggregations["avg"] {
+		return { type: "avg", name, field };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\CountAggregation
+	 * Allows to calculate the count value for the provided field
+	 */
+	static count(name: string, field: string): Aggregations["count"] {
+		return { type: "count", name, field };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\MaxAggregation
+	 * Allows to calculate the max value for the provided field
+	 */
+	static max(name: string, field: string): Aggregations["max"] {
+		return { type: "max", name, field };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\MinAggregation
+	 * Allows to calculate the min value for the provided field
+	 */
+	static min(name: string, field: string): Aggregations["min"] {
+		return { type: "min", name, field };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\StatsAggregation
+	 * Allows to calculate the sum, max, min, avg, count values for the provided field
+	 */
+	static stats(name: string, field: string): Aggregations["stats"] {
+		return { type: "stats", name, field };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\SumAggregation
+	 * Allows to calculate the sum value for the provided field
+	 */
+	static sum(name: string, field: string): Aggregations["sum"] {
+		return { type: "sum", name, field };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\TermsAggregation
+	 * Allows to fetch term buckets for the provided field
+	 */
+	static terms(
+		name: string,
+		field: string,
+		limit: number | null = null,
+		sort: Sorting | null = null,
+		aggregation: Aggregation | null = null,
+	): Aggregations["terms"] {
+		return { type: "terms", name, field, limit, sort, aggregation };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Metric\EntityAggregation
+	 * Allows to filter an aggregation result
+	 */
+	static entityAggregation(
+		name: string,
+		field: string,
+		definition: string,
+	): Aggregations["entity"] {
+		return { type: "entity", name, field, definition };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\FilterAggregation
+	 * Allows to filter an aggregation result
+	 */
+	static filter(
+		name: string,
+		filter: SingleFilter[],
+		aggregation: Aggregation,
+	): Aggregations["filter"] {
+		return { type: "filter", name, filter, aggregation };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Aggregation\Bucket\DateHistogramAggregation
+	 * Allows to fetch date buckets for the provided date interval
+	 */
+	static histogram(
+		name: string,
+		field: string,
+		interval: string | null,
+		format: string | null,
+		aggregation: Aggregation | null,
+		timeZone: string | null,
+	): Aggregations["histogram"] {
+		return {
+			type: "histogram",
+			name,
+			field,
+			interval,
+			format,
+			aggregation,
+			timeZone,
+		};
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting.
+	 * Allows to sort the documents by the provided field
+	 */
+	static sort(
+		field: string,
+		order: Sorting["order"] = "ASC",
+		naturalSorting = false,
+	): Sorting {
+		return { field, order, naturalSorting };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\FieldSorting.
+	 * Allows to sort the documents by the provided field naturally
+	 */
+	static naturalSorting(
+		field: string,
+		order: Sorting["order"] = "ASC",
+	): Sorting {
+		return { field, order, naturalSorting: true };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Sorting\CountSorting.
+	 * Allows to sort the documents by counting associations via the provided field
+	 *
+	 * Sql representation: `ORDER BY COUNT({field}) {order}`
+	 */
+	static countSorting(field: string, order: Sorting["order"] = "ASC"): Sorting {
+		return { field, order, naturalSorting: false, type: "count" };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\ContainsFilter.
+	 * This allows to filter documents where the value are contained in the provided field.
+	 *
+	 * Sql representation: `{field} LIKE %{value}%`
+	 */
+	static contains(field: string, value: string): Filters["contains"] {
+		return { type: "contains", field, value };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\PrefixFilter.
+	 * This allows to filter documents where the value marks the beginning of the provided field.
+	 *
+	 * Sql representation: `{field} LIKE {value}%`
+	 */
+	static prefix(field: string, value: string): Filters["prefix"] {
+		return { type: "prefix", field, value };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\SuffixFilter.
+	 * This allows to filter documents where the value marks the end of the provided field.
+	 *
+	 * Sql representation: `{field} LIKE %{value}`
+	 */
+	static suffix(field: string, value: string): Filters["suffix"] {
+		return { type: "suffix", field, value };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsAnyFilter.
+	 * This allows to filter documents where the field matches one of the provided values
+	 *
+	 * Sql representation: `{field} IN ({value}, {value})`
+	 */
+	static equalsAny(
+		field: string,
+		value: (string | number | boolean | null)[],
+	): Filters["equalsAny"] {
+		return { type: "equalsAny", field, value: value.join("|") };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter.
+	 * This allows to filter documents where the field matches a defined range
+	 *
+	 * Sql representation: `{field} >= {value}`, `{field} <= {value}`, ...
+	 */
+	static range(
+		field: string,
+		range: Filters["range"]["parameters"],
+	): Filters["range"] {
+		return { type: "range", field, parameters: range };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter.
+	 * This allows to filter documents where the field matches a defined range
+	 *
+	 * Sql representation: `{field} = {value}`
+	 */
+	static equals(
+		field: string,
+		value: string | number | boolean | null,
+	): Filters["equals"] {
+		return { type: "equals", field, value };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter.
+	 * This allows to filter documents which not matches for the provided filters
+	 * All above listed queries can be provided (equals, equalsAny, range, contains)
+	 *
+	 * Sql representation: `NOT({query} {operator} {query} {operator} {query})`
+	 *
+	 * @param {string} operator - and/or
+	 * @param {array} queries
+	 *
+	 * @returns {Object}
+	 */
+	static not(
+		operator: Filters["not"]["operator"],
+		queries: SingleFilter[] = [],
+	): Filters["not"] {
+		return { type: "not", operator: operator, queries: queries };
+	}
+
+	/**
+	 * @see \Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter.
+	 * This allows to filter documents which matches for the provided filters
+	 * All above listed queries can be provided (equals, equalsAny, range, contains)
+	 *
+	 * Sql representation: `({query} {operator} {query} {operator} {query})`
+	 *
+	 * @param {string} operator - and/or
+	 * @param {array} queries
+	 *
+	 * @returns {Object}
+	 */
+	static multi(
+		operator: Filters["multi"]["operator"],
+		queries: SingleFilter[] = [],
+	): Filters["multi"] {
+		return { type: "multi", operator, queries };
+	}
+}

--- a/src/http-client.test.ts
+++ b/src/http-client.test.ts
@@ -109,11 +109,13 @@ describe("HTTP Client", async () => {
 		const client = new HttpClient(new SimpleShop("blaa", "test", "test"));
 
 		mockFetch.mockImplementation(() =>
-			Promise.resolve(new Response('{"data": "test"}', { status: 400 })),
+			Promise.resolve(
+				new Response('{"errors": [{"detail": "test"}]}', { status: 400 }),
+			),
 		);
 
 		expect(client.get("/test")).rejects.toThrowError(
-			"The api request failed with status code: 400 for shop with id: blaa",
+			"Request failed with error: test for shop with id: bla",
 		);
 
 		mockFetch.mockRestore();

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -222,8 +222,8 @@ export class ApiClientRequestFailed extends Error {
 		shopId: string,
 		public response: HttpClientResponse<ShopwareErrorResponse>,
 	) {
-		super(
-			`The api request failed with status code: ${response.statusCode} for shop with id: ${shopId}`,
-		);
+		const message = response.body.errors.map((e) => e.detail).join(", ");
+
+		super(`Request failed with error: ${message} for shop with id: ${shopId}`);
 	}
 }

--- a/src/integration/hono.test.ts
+++ b/src/integration/hono.test.ts
@@ -129,4 +129,61 @@ describe("Hono", async () => {
 			"4a43a105ccce57e8e38d4a1f7b3565d743b1e15fb1fec36f41fdf20164fa1c8b",
 		);
 	});
+
+	test("app activate", async () => {
+		const hono = new Hono();
+
+		configureAppServer(hono, {
+			appName: "test",
+			appSecret: "test",
+			shopRepository: repo,
+		});
+
+		const resp = await hono.fetch(
+			new Request("http://localhost/app/activate", {
+				method: "POST",
+				body: "{}",
+			}),
+		);
+
+		expect(resp.status).toBe(500);
+	});
+
+	test("app deactivate", async () => {
+		const hono = new Hono();
+
+		configureAppServer(hono, {
+			appName: "test",
+			appSecret: "test",
+			shopRepository: repo,
+		});
+
+		const resp = await hono.fetch(
+			new Request("http://localhost/app/deactivate", {
+				method: "POST",
+				body: "{}",
+			}),
+		);
+
+		expect(resp.status).toBe(500);
+	});
+
+	test("app delete", async () => {
+		const hono = new Hono();
+
+		configureAppServer(hono, {
+			appName: "test",
+			appSecret: "test",
+			shopRepository: repo,
+		});
+
+		const resp = await hono.fetch(
+			new Request("http://localhost/app/delete", {
+				method: "POST",
+				body: "{}",
+			}),
+		);
+
+		expect(resp.status).toBe(500);
+	});
 });


### PR DESCRIPTION
example usage

```ts
import { EntityRepository, } from "@shopware-ag/app-server-sdk/helper/admin-api";
import { createNotificationResponse } from "@shopware-ag/app-server-sdk/helper/app-actions";
import { Criteria } from "@shopware-ag/app-server-sdk/helper/criteria";

type Product = {
  id: string;
  name: string;
};

app.post("/app/action-button", async (c) => {
  const ctx = c.get("context") as Context<SimpleShop, ActionButtonRequest>;

  const repository = new EntityRepository<Product>(ctx.httpClient, "product");

  // get the products clicked by action button
  const entitySearchResult = await repository.search(new Criteria(ctx.payload.data.ids));

  console.log(entitySearchResult.total);
  console.log(entitySearchResult.data[0].name)

  await repository.upsert(entitySearchResult.data.map(product => ({ id: product.id, name: 'yippiee' })));

  return createNotificationResponse("success", "Product name updated yeaaa");
});\
```