### PR TITLE
fix: set shop inactive by default

### DIFF
--- a/src/integration/dynamodb.test.ts
+++ b/src/integration/dynamodb.test.ts
@@ -79,7 +79,7 @@ describe("DynamoDB", async () => {
 		// @ts-expect-error
 		expect(cmd.input.Item).toEqual({
 			id: "a",
-			active: true,
+			active: false,
 			url: "b",
 			secret: "c",
 			clientId: null,
@@ -114,7 +114,7 @@ describe("DynamoDB", async () => {
 		// @ts-expect-error
 		expect(cmd.input.Item).toEqual({
 			id: "a",
-			active: true,
+			active: false,
 			url: "b",
 			secret: "c",
 			clientId: null,

--- a/src/integration/dynamodb.ts
+++ b/src/integration/dynamodb.ts
@@ -21,7 +21,7 @@ export class DynamoDBRepository implements ShopRepositoryInterface<SimpleShop> {
 			TableName: this.tableName,
 			Item: {
 				id: id,
-				active: true,
+				active: false,
 				url: url,
 				secret: secret,
 				clientId: null,

--- a/src/repository.test.ts
+++ b/src/repository.test.ts
@@ -10,11 +10,11 @@ describe("Repository", async () => {
 		expect(shop.getShopSecret()).toBe("test");
 		expect(shop.getShopClientId()).toBeNull();
 		expect(shop.getShopClientSecret()).toBeNull();
-		expect(shop.getShopActive()).toBe(true);
-
-		shop.setShopActive(false);
-
 		expect(shop.getShopActive()).toBe(false);
+
+		shop.setShopActive(true);
+
+		expect(shop.getShopActive()).toBe(true);
 
 		shop.setShopCredentials("test", "test");
 

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -35,7 +35,7 @@ export class SimpleShop implements ShopInterface {
 	private shopSecret: string;
 	private shopClientId: string | null;
 	private shopClientSecret: string | null;
-	private shopActive = true;
+	private shopActive = false;
 
 	constructor(shopId: string, shopUrl: string, shopSecret: string) {
 		this.shopId = shopId;


### PR DESCRIPTION
Upon registration the shop is inactive and remains so until an activation webhook is triggered.