### PR TITLE
feat: return mediaId on successful uploadMediaFile

### DIFF
--- a/src/helper/media.test.ts
+++ b/src/helper/media.test.ts
@@ -131,11 +131,12 @@ describe("Test Media helper", () => {
 			},
 		} as unknown as HttpClient;
 
-		await uploadMediaFile(client, {
+		const response = await uploadMediaFile(client, {
 			file: new Blob(["test"], { type: "text/plain" }),
 			fileName: "test.text",
 		});
 
+		expect(typeof response).toBe("string");
 		expect(requests).toBeArrayOfSize(2);
 		expect(requests[0]?.url).toBe("/_action/sync");
 		expect(requests[0]?.data).toEqual([

--- a/src/helper/media.ts
+++ b/src/helper/media.ts
@@ -11,6 +11,7 @@ import { Criteria } from "./criteria.js";
  * @param {string} [options.mediaFolderId] - The ID of the media folder to upload the file to.
  * @param {string} options.fileName - The name of the file to upload.
  * @param {Blob|Promise<Blob>} options.file - The file to upload.
+ * @returns {Promise<string>} - The ID of the uploaded media file.
  */
 export async function uploadMediaFile(
 	httpClient: HttpClient,
@@ -25,7 +26,7 @@ export async function uploadMediaFile(
 		fileName: string;
 		file: Blob | Promise<Blob>;
 	},
-) {
+): Promise<string> {
 	const repository = new EntityRepository(httpClient, "media");
 
 	const mediaId = uuid();
@@ -62,6 +63,8 @@ export async function uploadMediaFile(
 				"Content-Type": resolved.type,
 			},
 		);
+
+		return mediaId;
 	} catch (e) {
 		await repository.delete([{ id: mediaId }]);
 		throw e;


### PR DESCRIPTION
This is necessary as otherwise you would not know the media created and would not be able to use them afterwards.