### PR TITLE
feat: add event handling for shop authorization

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,5 @@
 import { ContextResolver } from "./context-resolver.js";
+import { Hooks } from "./hooks.js";
 import { Registration } from "./registration.js";
 import type { ShopInterface, ShopRepositoryInterface } from "./repository.js";
 import { WebCryptoHmacSigner } from "./signer.js";
@@ -7,17 +8,19 @@ import { WebCryptoHmacSigner } from "./signer.js";
  * AppServer is the main class, this is where you start your app
  */
 export class AppServer<Shop extends ShopInterface = ShopInterface> {
-	public registration: Registration;
+	public registration: Registration<Shop>;
 	public contextResolver: ContextResolver<Shop>;
 	public signer: WebCryptoHmacSigner;
+	public hooks: Hooks<Shop>;
 
 	constructor(
 		public cfg: Configuration,
 		public repository: ShopRepositoryInterface<Shop>,
 	) {
-		this.registration = new Registration(this);
-		this.contextResolver = new ContextResolver(this);
+		this.registration = new Registration<Shop>(this);
+		this.contextResolver = new ContextResolver<Shop>(this);
 		this.signer = new WebCryptoHmacSigner();
+		this.hooks = new Hooks<Shop>();
 	}
 }
 

--- a/src/context-resolver.ts
+++ b/src/context-resolver.ts
@@ -7,7 +7,7 @@ import type { ShopInterface } from "./repository.js";
  * The context contains the shop, the payload and an instance of the HttpClient
  */
 export class ContextResolver<Shop extends ShopInterface = ShopInterface> {
-	constructor(private app: AppServer) {}
+	constructor(private app: AppServer<Shop>) {}
 
 	/**
 	 * Create a context from a request body

--- a/src/hooks.test.ts
+++ b/src/hooks.test.ts
@@ -1,0 +1,70 @@
+import { beforeAll, describe, expect, jest, test } from "bun:test";
+import { Hooks } from "./hooks.js";
+import { ShopAuthroizeEvent } from "./registration.js";
+import { SimpleShop } from "./repository.js";
+
+describe("Hooks", () => {
+	let hooks: Hooks;
+
+	beforeAll(() => {
+		hooks = new Hooks();
+	});
+
+	test("should register an event listener", () => {
+		const mockCallback = jest.fn();
+		hooks.on("onAuthorize", mockCallback);
+
+		expect(hooks.hasListeners("onAuthorize")).toBe(true);
+	});
+
+	test("should call the registered event listener on publish", async () => {
+		const mockCallback = jest.fn().mockResolvedValue(new Response());
+		hooks.on("onAuthorize", mockCallback);
+
+		const mockEvent = new ShopAuthroizeEvent(
+			new Request("https://example.com"),
+			new SimpleShop("shop1", "http://localhost", "test"),
+		);
+		await hooks.publish("onAuthorize", mockEvent);
+
+		expect(mockCallback).toHaveBeenCalledWith(mockEvent);
+	});
+
+	test("should handle multiple listeners for the same event", async () => {
+		const mockCallback1 = jest.fn().mockResolvedValue(new Response());
+		const mockCallback2 = jest.fn().mockResolvedValue(new Response());
+		hooks.on("onAuthorize", mockCallback1);
+		hooks.on("onAuthorize", mockCallback2);
+
+		const mockEvent = new ShopAuthroizeEvent(
+			new Request("https://example.com"),
+			new SimpleShop("shop1", "http://localhost", "test"),
+		);
+		await hooks.publish("onAuthorize", mockEvent);
+
+		expect(mockCallback1).toHaveBeenCalledWith(mockEvent);
+		expect(mockCallback2).toHaveBeenCalledWith(mockEvent);
+	});
+
+	test("should not fail if no listeners are registered for an event", async () => {
+		const mockEvent = new ShopAuthroizeEvent(
+			new Request("https://example.com"),
+			new SimpleShop("shop1", "http://localhost", "test"),
+		);
+		expect(hooks.publish("onAuthorize", mockEvent)).resolves.toBeUndefined();
+	});
+
+	test("should await promises returned by listeners", async () => {
+		const mockCallback = jest.fn().mockResolvedValue(new Response());
+		hooks.on("onAuthorize", mockCallback);
+
+		const mockEvent = new ShopAuthroizeEvent(
+			new Request("https://example.com"),
+			new SimpleShop("shop1", "http://localhost", "test"),
+		);
+		const publishPromise = hooks.publish("onAuthorize", mockEvent);
+
+		expect(hooks.publish("onAuthorize", mockEvent)).resolves.toBeUndefined();
+		expect(mockCallback).toHaveBeenCalledWith(mockEvent);
+	});
+});

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,0 +1,47 @@
+import type { ShopAuthroizeEvent } from "./registration.js";
+import type { ShopInterface } from "./repository.js";
+
+interface HookRegistry<Shop extends ShopInterface> {
+	onAuthorize: (event: ShopAuthroizeEvent<Shop>) => Promise<void>;
+}
+
+export class Hooks<Shop extends ShopInterface = ShopInterface> {
+	private eventListeners = new Map<
+		keyof HookRegistry<Shop>,
+		HookRegistry<Shop>[keyof HookRegistry<Shop>][]
+	>();
+
+	hasListeners(event: keyof HookRegistry<Shop>): boolean {
+		return this.eventListeners.has(event);
+	}
+
+	on(
+		event: keyof HookRegistry<Shop>,
+		cb: HookRegistry<Shop>[keyof HookRegistry<Shop>],
+	) {
+		if (!this.eventListeners.has(event)) {
+			this.eventListeners.set(event, []);
+		}
+
+		this.eventListeners.get(event)?.push(cb);
+	}
+
+	async publish(
+		event: keyof HookRegistry<Shop>,
+		...args: Parameters<HookRegistry<Shop>[keyof HookRegistry<Shop>]>
+	): Promise<void> {
+		const events = this.eventListeners.get(event);
+
+		if (!events) {
+			return;
+		}
+
+		for (const cb of events) {
+			const res = cb(...args);
+
+			if (res instanceof Promise) {
+				await res;
+			}
+		}
+	}
+}

--- a/src/integration/hono.ts
+++ b/src/integration/hono.ts
@@ -99,6 +99,11 @@ interface MiddlewareConfig {
 	shopRepository:
 		| ShopRepositoryInterface
 		| ((c: HonoContext) => ShopRepositoryInterface);
+
+	/**
+	 * A callback to setup the app server. It will be called after the app server is created and before the first request is handled
+	 */
+	setup?: (app: AppServer) => void;
 }
 
 /**
@@ -141,6 +146,10 @@ export function configureAppServer(hono: Hono, cfg: MiddlewareConfig) {
 				},
 				cfg.shopRepository,
 			);
+
+			if (cfg.setup) {
+				cfg.setup(app);
+			}
 		}
 
 		// @ts-ignore

--- a/src/repository.ts
+++ b/src/repository.ts
@@ -16,7 +16,9 @@ export interface ShopInterface {
  * ShopRepositoryInterface is the storage interface for the shops, you should implement this to save the shop data to your database
  * For testing cases the InMemoryShopRepository can be used
  */
-export interface ShopRepositoryInterface<Shop = ShopInterface> {
+export interface ShopRepositoryInterface<
+	Shop extends ShopInterface = ShopInterface,
+> {
 	createShop(id: string, url: string, secret: string): Promise<void>;
 
 	getShopById(id: string): Promise<Shop | null>;


### PR DESCRIPTION
example use-case:

```js
configureAppServer(app, {
  appName: "Test",
  appSecret: "Test",
  shopRepository: new BunSqliteRepository('shop.db'),
  setup: (app) => {
    app.hooks.on("onAuthorize", async (ctx) => {
      const httpClient = new HttpClient(ctx.shop);

      try {
        await httpClient.get('_action/version')
      } catch (e) {
        if (e instanceof ApiClientAuthenticationFailed && e.response.statusCode === 401) {
          return;
        }
      }

      ctx.rejectRegistration('Your Webserver is not reachable from the internet');
    });
  },
});
```