### PR TITLE
fix: do not override shops when updating or re-creating

### DIFF
--- a/src/integration/dynamodb.test.ts
+++ b/src/integration/dynamodb.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, mock, test } from "bun:test";
 import { DynamoDBRepository } from "./dynamodb.js";
 
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
-import type { DeleteCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import type {
+	DeleteCommand,
+	PutCommand,
+	UpdateCommand,
+} from "@aws-sdk/lib-dynamodb";
 import { SimpleShop } from "../repository.js";
 
 describe("DynamoDB", async () => {
@@ -88,14 +92,14 @@ describe("DynamoDB", async () => {
 	});
 
 	test("updateShop", async () => {
-		let cmd: PutCommand;
+		let cmd: UpdateCommand;
 
 		mock.module("@aws-sdk/lib-dynamodb", () => {
 			return {
 				DynamoDBDocumentClient: {
 					from() {
 						return {
-							async send(inner: PutCommand) {
+							async send(inner: UpdateCommand) {
 								cmd = inner;
 								return {};
 							},
@@ -112,13 +116,12 @@ describe("DynamoDB", async () => {
 		// @ts-expect-error
 		expect(cmd).toBeDefined();
 		// @ts-expect-error
-		expect(cmd.input.Item).toEqual({
-			id: "a",
-			active: false,
-			url: "b",
-			secret: "c",
-			clientId: null,
-			clientSecret: null,
+		expect(cmd.input.ExpressionAttributeValues).toEqual({
+			":active": false,
+			":url": "b",
+			":secret": "c",
+			":clientId": null,
+			":clientSecret": null,
 		});
 	});
 

--- a/src/integration/dynamodb.ts
+++ b/src/integration/dynamodb.ts
@@ -4,6 +4,7 @@ import {
 	DynamoDBDocumentClient,
 	GetCommand,
 	PutCommand,
+	UpdateCommand,
 } from "@aws-sdk/lib-dynamodb";
 import { type ShopRepositoryInterface, SimpleShop } from "../repository.js";
 
@@ -69,15 +70,19 @@ export class DynamoDBRepository implements ShopRepositoryInterface<SimpleShop> {
 	}
 
 	async updateShop(shop: SimpleShop): Promise<void> {
-		const cmd = new PutCommand({
+		const cmd = new UpdateCommand({
 			TableName: this.tableName,
-			Item: {
-				id: shop.getShopId(),
-				active: shop.getShopActive(),
-				url: shop.getShopUrl(),
-				secret: shop.getShopSecret(),
-				clientId: shop.getShopClientId(),
-				clientSecret: shop.getShopClientSecret(),
+			Key: { "id": { "S": shop.getShopId() } },
+			UpdateExpression: "SET active = :active, #u = :url, secret = :secret, clientId = :clientId, clientSecret = :clientSecret",
+			ExpressionAttributeNames: {
+				"#u": "url",
+			},
+			ExpressionAttributeValues: {
+				":active": { "BOOL": shop.getShopActive() },
+				":url": { "S": shop.getShopUrl() },
+				":secret": { "S": shop.getShopSecret() },
+				":clientId": { "S": shop.getShopClientId() },
+				":clientSecret": { "S": shop.getShopClientSecret() },
 			},
 		});
 

--- a/src/integration/dynamodb.ts
+++ b/src/integration/dynamodb.ts
@@ -72,17 +72,18 @@ export class DynamoDBRepository implements ShopRepositoryInterface<SimpleShop> {
 	async updateShop(shop: SimpleShop): Promise<void> {
 		const cmd = new UpdateCommand({
 			TableName: this.tableName,
-			Key: { "id": { "S": shop.getShopId() } },
-			UpdateExpression: "SET active = :active, #u = :url, secret = :secret, clientId = :clientId, clientSecret = :clientSecret",
+			Key: { id: shop.getShopId() },
+			UpdateExpression:
+				"SET active = :active, #u = :url, secret = :secret, clientId = :clientId, clientSecret = :clientSecret",
 			ExpressionAttributeNames: {
 				"#u": "url",
 			},
 			ExpressionAttributeValues: {
-				":active": { "BOOL": shop.getShopActive() },
-				":url": { "S": shop.getShopUrl() },
-				":secret": { "S": shop.getShopSecret() },
-				":clientId": { "S": shop.getShopClientId() },
-				":clientSecret": { "S": shop.getShopClientSecret() },
+				":active": shop.getShopActive(),
+				":url": shop.getShopUrl(),
+				":secret": shop.getShopSecret(),
+				":clientId": shop.getShopClientId(),
+				":clientSecret": shop.getShopClientSecret(),
 			},
 		});
 


### PR DESCRIPTION
* Use `UpdateCommand` instead of `PutCommand` in `updateShop()` to avoid overriding the whole item instead of just updating single fields.
* 