### PR TITLE
fix: shop url contains the slash at the end will cause the bug

### DIFF
--- a/src/registration.ts
+++ b/src/registration.ts
@@ -22,7 +22,9 @@ export class Registration<Shop extends ShopInterface = ShopInterface> {
 		}
 
 		const shopId = url.searchParams.get("shop-id") as string;
-		const shopUrl = (url.searchParams.get("shop-url") as string).toString().replace(/\/+$/, '');
+		const shopUrl = (url.searchParams.get("shop-url") as string)
+			.toString()
+			.replace(/\/+$/, "");
 		const timestamp = url.searchParams.get("timestamp") as string;
 
 		const v = await this.app.signer.verify(

--- a/src/registration.ts
+++ b/src/registration.ts
@@ -22,7 +22,7 @@ export class Registration<Shop extends ShopInterface = ShopInterface> {
 		}
 
 		const shopId = url.searchParams.get("shop-id") as string;
-		const shopUrl = url.searchParams.get("shop-url") as string;
+		const shopUrl = (url.searchParams.get("shop-url") as string).toString().replace(/\/+$/, '');
 		const timestamp = url.searchParams.get("timestamp") as string;
 
 		const v = await this.app.signer.verify(


### PR DESCRIPTION
There is a case `shopUrl` saved in db with `https://example.com/`. Because of the slash symbol at the end of shop url, everytime the app gets token will throw an error with wrong api endpoint `https://example.com//api/oauth/token`.

This fixes make sure the shopUrl will be saved the domain value without slash symbol at the end.