### PR TITLE
Allow passing AppServer instance directly to Hono middleware

### DIFF
--- a/src/context-resolver.test.ts
+++ b/src/context-resolver.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, jest, test } from "bun:test";
 import { AppServer } from "../src/app.js";
 import { ContextResolver } from "../src/context-resolver.js";
+import { InMemoryHttpClientTokenCache } from "../src/http-client.js";
 import { InMemoryShopRepository, SimpleShop } from "../src/repository.js";
 
 describe("Context Resolver", async () => {
@@ -15,7 +16,7 @@ describe("Context Resolver", async () => {
 
 	await app.repository.createShop("blaa", "test", "test");
 
-	const contextResolver = new ContextResolver(app);
+	const contextResolver = new ContextResolver(app, new InMemoryHttpClientTokenCache());
 
 	test("fromBrowser: shop does not exist", async () => {
 		expect(

--- a/src/helper/criteria.test.ts
+++ b/src/helper/criteria.test.ts
@@ -20,11 +20,11 @@ describe("Test Criteria class", () => {
 	test("add assosication", () => {
 		const criteria = new Criteria();
 
-		criteria.addAssociation("foo");
+		criteria.addAssociation("foo.bar");
 
 		const obj = criteria.toPayload();
 
-		expect(obj.associations).toEqual({ foo: {} });
+		expect(obj.associations).toEqual({ foo: { associations: { bar: {} } } });
 	});
 
 	test("add nested assosication", () => {

--- a/src/http-client.test.ts
+++ b/src/http-client.test.ts
@@ -2,6 +2,18 @@ import { describe, expect, mock, spyOn, test } from "bun:test";
 import { HttpClient, InMemoryHttpClientTokenCache } from "../src/http-client.js";
 import { SimpleShop } from "../src/repository.js";
 
+function createMockFetch(response: Response) {
+	const mockImpl = mock(() => Promise.resolve(response));
+	Object.assign(mockImpl, { preconnect: () => {} });
+	return spyOn(global, "fetch").mockImplementation(mockImpl as unknown as typeof fetch);
+}
+
+function createMockFetchImpl(response: Response) {
+	const mockImpl = mock(() => Promise.resolve(response));
+	Object.assign(mockImpl, { preconnect: () => {} });
+	return mockImpl as unknown as typeof fetch;
+}
+
 describe("InMemoryHttpClientTokenCache", () => {
   test("it stores, retrieves, and clears tokens", async () => {
     const cache = new InMemoryHttpClientTokenCache();
@@ -25,10 +37,8 @@ describe("InMemoryHttpClientTokenCache", () => {
 
 describe("HTTP Client", async () => {
 	test("getToken", async () => {
-		const mockFetch = spyOn(global, "fetch").mockImplementation(() =>
-			Promise.resolve(
-				new Response('{"access_token": "test", "expires_in": 3600}'),
-			),
+		const mockFetch = createMockFetch(
+			new Response('{"access_token": "test", "expires_in": 3600}')
 		);
 
 		const client = new HttpClient(new SimpleShop("blaa", "test", "test"));
@@ -43,10 +53,8 @@ describe("HTTP Client", async () => {
 	});
 
 	test("getToken: failed request", async () => {
-		const mockFetch = spyOn(global, "fetch").mockImplementation(() =>
-			Promise.resolve(
-				new Response('{"error": "invalid_grant"}', { status: 400 }),
-			),
+		const mockFetch = createMockFetch(
+			new Response('{"error": "invalid_grant"}', { status: 400 })
 		);
 
 		const client = new HttpClient(new SimpleShop("blaa", "test", "test"));
@@ -58,10 +66,8 @@ describe("HTTP Client", async () => {
 	});
 
 	test("getToken: expired refetch", async () => {
-		const mockFetch = spyOn(global, "fetch").mockImplementation(() =>
-			Promise.resolve(
-				new Response('{"access_token": "test", "expires_in": -500}'),
-			),
+		const mockFetch = createMockFetch(
+			new Response('{"access_token": "test", "expires_in": -500}')
 		);
 
 		const client = new HttpClient(new SimpleShop("blaa", "test", "test"));
@@ -77,16 +83,14 @@ describe("HTTP Client", async () => {
 	});
 
 	test("get, post, put, patch, delete", async () => {
-		const mockFetch = spyOn(global, "fetch").mockImplementationOnce(() =>
-			Promise.resolve(
-				new Response('{"access_token": "test", "expires_in": 5000}'),
-			),
+		const mockFetch = spyOn(global, "fetch").mockImplementationOnce(
+			createMockFetchImpl(new Response('{"access_token": "test", "expires_in": 5000}'))
 		);
 
 		const client = new HttpClient(new SimpleShop("blaa", "test", "test"));
 
-		mockFetch.mockImplementation(() =>
-			Promise.resolve(new Response('{"data": "test"}')),
+		mockFetch.mockImplementation(
+			createMockFetchImpl(new Response('{"data": "test"}'))
 		);
 
 		expect(client.get("/test")).resolves.toEqual({
@@ -121,10 +125,8 @@ describe("HTTP Client", async () => {
 	});
 
 	test("post: send a body data form data", async () => {
-		const mockFetch = spyOn(global, "fetch").mockImplementation(() =>
-			Promise.resolve(
-				new Response('{"access_token": "test", "expires_in": 5000}'),
-			),
+		const mockFetch = createMockFetch(
+			new Response('{"access_token": "test", "expires_in": 5000}')
 		);
 
 		const client = new HttpClient(new SimpleShop("blaa", "test", "test"));
@@ -152,10 +154,8 @@ describe("HTTP Client", async () => {
 	});
 
 	test("post: regular object", async () => {
-		const mockFetch = spyOn(global, "fetch").mockImplementation(() =>
-			Promise.resolve(
-				new Response('{"access_token": "test", "expires_in": 5000}'),
-			),
+		const mockFetch = createMockFetch(
+			new Response('{"access_token": "test", "expires_in": 5000}')
 		);
 
 		const client = new HttpClient(new SimpleShop("blaa", "test", "test"));
@@ -183,18 +183,14 @@ describe("HTTP Client", async () => {
 	});
 
 	test("get: request failed", async () => {
-		const mockFetch = spyOn(global, "fetch").mockImplementationOnce(() =>
-			Promise.resolve(
-				new Response('{"access_token": "test", "expires_in": 5000}'),
-			),
+		const mockFetch = spyOn(global, "fetch").mockImplementationOnce(
+			createMockFetchImpl(new Response('{"access_token": "test", "expires_in": 5000}'))
 		);
 
 		const client = new HttpClient(new SimpleShop("blaa", "test", "test"));
 
-		mockFetch.mockImplementation(() =>
-			Promise.resolve(
-				new Response('{"errors": [{"detail": "test"}]}', { status: 400 }),
-			),
+		mockFetch.mockImplementation(
+			createMockFetchImpl(new Response('{"errors": [{"detail": "test"}]}', { status: 400 }))
 		);
 
 		expect(client.get("/test")).rejects.toThrowError(
@@ -205,8 +201,8 @@ describe("HTTP Client", async () => {
 	});
 
 	test("test authentification gets redirect", async () => {
-		const mockFetch = spyOn(global, "fetch").mockImplementationOnce(() =>
-			Promise.resolve(new Response("", { status: 301 })),
+		const mockFetch = spyOn(global, "fetch").mockImplementationOnce(
+			createMockFetchImpl(new Response("", { status: 301 }))
 		);
 
 		const client = new HttpClient(new SimpleShop("blaa", "test", "test"));
@@ -219,17 +215,16 @@ describe("HTTP Client", async () => {
 	});
 
 	test("gets redirect on a api route", async () => {
-		const mockFetch = spyOn(global, "fetch").mockImplementation(
-			(input, init) => {
-				if (input === "test/api/oauth/token") {
-					return Promise.resolve(
-						new Response('{"access_token": "test", "expires_in": 5000}'),
-					);
-				}
-
-				return Promise.resolve(new Response("", { status: 301 }));
-			},
-		);
+		const mockFetchFunc = (input: any, init: any) => {
+			if (input === "test/api/oauth/token") {
+				return Promise.resolve(
+					new Response('{"access_token": "test", "expires_in": 5000}'),
+				);
+			}
+			return Promise.resolve(new Response("", { status: 301 }));
+		};
+		Object.assign(mockFetchFunc, { preconnect: () => {} });
+		const mockFetch = spyOn(global, "fetch").mockImplementation(mockFetchFunc as typeof fetch);
 
 		const client = new HttpClient(new SimpleShop("blaa", "test", "test"));
 
@@ -241,16 +236,14 @@ describe("HTTP Client", async () => {
 	});
 
 	test("timeout: successful request with timeout option", async () => {
-		const mockFetch = spyOn(global, "fetch").mockImplementation(() =>
-			Promise.resolve(
-				new Response('{"access_token": "test", "expires_in": 5000}'),
-			),
+		const mockFetch = createMockFetch(
+			new Response('{"access_token": "test", "expires_in": 5000}')
 		);
 
 		const client = new HttpClient(new SimpleShop("blaa", "test", "test"));
 
-		mockFetch.mockImplementation(() =>
-			Promise.resolve(new Response('{"data": "test"}')),
+		mockFetch.mockImplementation(
+			createMockFetchImpl(new Response('{"data": "test"}'))
 		);
 
 		const result = await client.get("/test", {}, { timeout: 5000 });
@@ -268,20 +261,20 @@ describe("HTTP Client", async () => {
 	});
 
 	test("timeout: request times out and throws error", async () => {
-		const mockFetch = spyOn(global, "fetch").mockImplementationOnce(() =>
-			Promise.resolve(
-				new Response('{"access_token": "test", "expires_in": 5000}'),
-			),
+		const mockFetch = spyOn(global, "fetch").mockImplementationOnce(
+			createMockFetchImpl(new Response('{"access_token": "test", "expires_in": 5000}'))
 		);
 
 		const client = new HttpClient(new SimpleShop("blaa", "test", "test"));
 
 		// Mock fetch to simulate timeout
-		mockFetch.mockImplementation(() => {
+		const abortErrorImpl = mock(() => {
 			const abortError = new Error("The operation was aborted");
 			abortError.name = "AbortError";
 			return Promise.reject(abortError);
 		});
+		Object.assign(abortErrorImpl, { preconnect: () => {} });
+		mockFetch.mockImplementation(abortErrorImpl as unknown as typeof fetch);
 
 		expect(client.get("/test", {}, { timeout: 1 })).rejects.toThrow("The operation was aborted");
 
@@ -289,16 +282,14 @@ describe("HTTP Client", async () => {
 	});
 
 	test("defaultTimeout: uses default timeout when no timeout option provided", async () => {
-		const mockFetch = spyOn(global, "fetch").mockImplementation(() =>
-			Promise.resolve(
-				new Response('{"access_token": "test", "expires_in": 5000}'),
-			),
+		const mockFetch = createMockFetch(
+			new Response('{"access_token": "test", "expires_in": 5000}')
 		);
 
 		const client = new HttpClient(new SimpleShop("blaa", "test", "test"), new InMemoryHttpClientTokenCache(), 3000);
 
-		mockFetch.mockImplementation(() =>
-			Promise.resolve(new Response('{"data": "test"}')),
+		mockFetch.mockImplementation(
+			createMockFetchImpl(new Response('{"data": "test"}'))
 		);
 
 		await client.get("/test");
@@ -310,16 +301,14 @@ describe("HTTP Client", async () => {
 	});
 
 	test("defaultTimeout: explicit timeout overrides default timeout", async () => {
-		const mockFetch = spyOn(global, "fetch").mockImplementation(() =>
-			Promise.resolve(
-				new Response('{"access_token": "test", "expires_in": 5000}'),
-			),
+		const mockFetch = createMockFetch(
+			new Response('{"access_token": "test", "expires_in": 5000}')
 		);
 
 		const client = new HttpClient(new SimpleShop("blaa", "test", "test"), new InMemoryHttpClientTokenCache(), 3000);
 
-		mockFetch.mockImplementation(() =>
-			Promise.resolve(new Response('{"data": "test"}')),
+		mockFetch.mockImplementation(
+			createMockFetchImpl(new Response('{"data": "test"}'))
 		);
 
 		await client.get("/test", {}, { timeout: 5000 });


### PR DESCRIPTION
This PR modifies the Hono integration to allow passing an already constructed AppServer instance through the MiddlewareConfig. It also adjusts the TypeScript types to enforce that either appServer OR the other parameters (appName, appSecret, shopRepository) are provided, but not both combinations at the same time.