### PR TITLE
feat: export InMemoryHttpClientTokenCache

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -6,6 +6,8 @@ export {
 	HttpClientResponse,
 	ApiClientAuthenticationFailed,
 	ApiClientRequestFailed,
+	InMemoryHttpClientTokenCache,
+	HttpClientTokenCacheInterface
 } from "./http-client.js";
 export { Context } from "./context-resolver.js";
 export {


### PR DESCRIPTION
I want to reuse the `InMemoryHttpClientTokenCache` and their interface instead of rewriting everything about it