### PR TITLE
feat: add the new criteria type for entity repository functions

### DIFF
--- a/src/helper/admin-api.test.ts
+++ b/src/helper/admin-api.test.ts
@@ -45,6 +45,24 @@ describe("EntityRepository", () => {
 		expect(res.first()).toBeNull();
 	});
 
+	test("search with request params", async () => {
+		const client = {
+			post(url: string, data: unknown, headers: Record<string, string>) {
+				expect(url).toBe("/search/product");
+				return Promise.resolve({ body: { total: 1, data: [] } });
+			},
+		} as unknown as HttpClient;
+
+		const repository = new EntityRepository(client, "product");
+		const params = new Criteria().toPayload();
+
+		const res = await repository.search(params);
+
+		expect(res.total).toBe(1);
+		expect(res.data).toEqual([]);
+		expect(res.first()).toBeNull();
+	});
+
 	test("search typed", async () => {
 		const client = {
 			post(url: string, data: unknown, headers: Record<string, string>) {

--- a/src/helper/criteria.ts
+++ b/src/helper/criteria.ts
@@ -139,7 +139,7 @@ interface Sorting {
 	naturalSorting: boolean;
 	type?: string;
 }
-interface RequestParams {
+export interface RequestParams {
 	ids?: string[];
 	page?: number;
 	limit?: number;


### PR DESCRIPTION
There is a case where I want to build the criteria on the frontend and attach it to the API request sent to the app server. The app server, acting as a proxy, will then forward the request to the shop instance’s Admin API with the payload.

Right now, this is not possible because the criteria have to be built in the same place where the shop instance’s API is called, which means you can only build the criteria on the app server. With this change, it becomes possible.